### PR TITLE
Fix for Auto Merging of Membership Updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,5 +44,5 @@ jobs:
           branch-suffix: timestamp
           path: ./landscape
           title: Update members
-          labels: automatedupdate
+          labels: automated-update
           commit-message: Update members


### PR DESCRIPTION
PRs generated by the build job were being incorrectly tagged with
'automatedupdate' and not 'automated-update'. The latter is the correct
tag the 'marksuccessfulbuild' job looks for which then applies the label
to automerge the change.

This should keep reviewers from needing to manually approve and merge
membership updates to the landscape.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>