### PR TITLE
Fixes the /pages/members to only include members

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -231,4 +231,4 @@ test:
 # if you have a common view, create a pre-render to speed the render time up
 prerender:
   # good pre-render to always have; embedable member logo list for a website. Renders to /pages/members
-  members: /card-mode?category=linux-foundation-networking-project-member-company&grouping=category&embed=yes&style=borderless
+  members: /card-mode?category=lf-networking-member-roster&grouping=category&embed=yes&style=borderless


### PR DESCRIPTION
The wrong category was being referenced.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>