### PR TITLE
Update Github Workflow action versions and token

### DIFF
--- a/.github/workflows/autocommit.yml
+++ b/.github/workflows/autocommit.yml
@@ -8,12 +8,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      issues: read
+      pull-requests: write
     steps:
       - name: Automerge Pull Request if possible
-        uses: "pascalgn/automerge-action@v0.13.0"
+        uses: "pascalgn/automerge-action@v0.15.5"
         env:
-          GITHUB_TOKEN: "${{ secrets.PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "automerge"
           MERGE_RETRY_SLEEP: 300000
           MERGE_METHOD: "squash"

--- a/.github/workflows/marksuccessfulbuild.yml
+++ b/.github/workflows/marksuccessfulbuild.yml
@@ -7,10 +7,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: write
     steps:
       - uses: Amwam/issue-comment-action@v1.3.1
         if: ${{ github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'automatedupdate') }}
         with:
           keywords: '["Deploy preview for *lfn-landscape* ready"]'
           labels: '["automerge"]'
-          github-token: "${{ secrets.PAT }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/update_members.yml
+++ b/.github/workflows/update_members.yml
@@ -9,19 +9,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      issues: read
+      pull-requests: write
     steps:
       - name: Checkout Landscape
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: landscape
       - name: Checkout landscape-tools
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: jmertic/landscape-tools
           path: landscape-tools
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install dependencies
@@ -33,14 +35,14 @@ jobs:
         run: |
           ../landscape-tools/landscapemembers.py
       - name: Save missing.csv file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: missing-members
           path: ./landscape/missing.csv
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch-suffix: timestamp
           path: ./landscape
           title: Update members


### PR DESCRIPTION
Bumps all versions actions to latest to remove deprecation warnings, and
replaces the secrets.PAT with secrets.GITHUB_TOKEN and includes
permission settings for the token.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
