### PR TITLE
Include 'contents: write' permissions in GHA

### DIFF
--- a/.github/workflows/autocommit.yml
+++ b/.github/workflows/autocommit.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       issues: read
       pull-requests: write
+      contents: write
     steps:
       - name: Automerge Pull Request if possible
         uses: "pascalgn/automerge-action@v0.15.5"

--- a/.github/workflows/update_members.yml
+++ b/.github/workflows/update_members.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       issues: read
       pull-requests: write
+      contents: write
     steps:
       - name: Checkout Landscape
         uses: actions/checkout@v3


### PR DESCRIPTION
This is causing the create-pull-request action to fail.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
