### PR TITLE
Fix ##[error]Resource not accessible by integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: jmertic/lfx-landscape-tools@beb983679eda9283caf216efdeea56ca6b8f83fe # 20260414
         with:


### PR DESCRIPTION
This happened when peter-evans/create-pull-request tried to open the PR via the GitHub API. The root cause is a permissions issue with the GITHUB_TOKEN. The token was granted only contents: write and metadata: read, but creating a pull request also requires pull-requests: write.