### PR TITLE
Fix bot-opened PRs never validating or auto-merging

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - master
+  pull_request_review:
+    types: [submitted]   
 
 permissions: {}
 
@@ -28,7 +30,11 @@ jobs:
           target_kind: data
           target_path: ./landscape.yml
       - uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
-        if: success() && ${{ github.secret_source == 'Actions' }}
+        if: >-
+          success()
+          && github.event_name == 'pull_request_review'
+          && github.event.review.state == 'approved'
+          && contains(github.event.pull_request.labels.*.name, 'automated-build')
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "automated-build"


### PR DESCRIPTION
## Problem

Daily PRs opened by the `Build Landscape from LFX` workflow (e.g. #569) are not triggering the `Validate Landscape` workflow, leaving them stuck indefinitely with no checks and no path to merge.

This is caused by GitHub's anti-recursion safeguard: workflows triggered by the default `GITHUB_TOKEN` cannot trigger further workflow runs via the `pull_request` event. Since the build workflow opens its PRs using `secrets.GITHUB_TOKEN`, the validate workflow never fires, pascalgn/automerge-action never runs, and the PR sits open forever.

## Fix

Align `validate.yml` with the pattern already proven out on CAMARA:

1. Add a `pull_request_review` trigger, which is not subject to the `GITHUB_TOKEN` suppression rule. Submitting an approving review causes the validate workflow to run.
2. Update the pascalgn/automerge-action condition to gate on review approval and the `automated-build` label, matching CAMARA.

No new secrets, no PAT, no GitHub App token required. The `GITHUB_TOKEN` with workflow permissions set to read and write is sufficient.

## Flow after this change

1. `Build Landscape from LFX` runs on the nightly cron and opens a PR as `github-actions[bot]`.
2. A maintainer applies the `automated-build` label and submits an approving review.
3. The `pull_request_review` event fires `Validate Landscape`, which validates `landscape.yml` and invokes pascalgn/automerge-action.
4. pascalgn sees an approved review with the `automated-build` label and squash-merges.

## Prerequisites in the repo

- `automated-build` label exists (adding separately).
- Settings → Actions → General → Workflow permissions set to "Read and write."
- Branch protection on `main` should not require checks or approvals that pascalgn cannot satisfy.

## Testing

After merge, I will close and rerun the bot so a fresh `pull_request` event fires, then apply the `automated-build` label and approve to confirm the full path works end to end before tomorrow's 04:00 UTC run.